### PR TITLE
initial terraform setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,9 @@ build/
 .vscode/
 
 .gradle/
-build/
+build/classes/
+build/generated/
+build/reports/
+build/resources/
+build/test-results/
+build/tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,11 @@ build/reports/
 build/resources/
 build/test-results/
 build/tmp/
+
+### Terraform  ###
+terraform/cred.json
+terraform/.terraform
+terraform/.terraform.lock.hcl
+terraform/.terraform.tfstate.lock.info
+terraform/terraform.tfstate
+terraform/terraform.tfstate.backup

--- a/README.md
+++ b/README.md
@@ -4,6 +4,23 @@ Discuss and ask questions in our Discussions: https://github.com/graphql-java/gr
 
 This is a test runner application to measure the performance of [GraphQL](https://github.com/graphql/graphql-spec) Java implementation.
 
+### Terraform and GCP project Setup
+
+1. Install terraform from [Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli)
+2. Verify terraform is working locally.
+3. Create a new gcp project.
+4. Create service account on IAM & Admin->Service Account-> Create Service Account.
+5. Give the role as Basic->Owner.
+6. Select the service account created above, then go to Actions->Manage keys->Add key->Create new key->JSON.
+7. Download the key from above step and paste it in the terraform directory. Rename it as **cred.json** .
+8. Open terminal in **terraform** directory.
+9. Run **terraform init** 
+10. Run **terraform apply -var project_id**=your project id present in **cred.json**.
+
+Terraform will take care of all the infrastructure required by the test runner.
+
+FYI: Firestore can be enabled only once per project and it can never be destroyed.
+
 ### Code of Conduct
 
 Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ This is a test runner application to measure the performance of [GraphQL](https:
 
 ### Terraform and GCP project Setup
 
+In order to orchestrate all gcp infrastructure we have used terraform, an open source infrastructure as code software tool that enables you to safely and predictably create, change, and improve infrastructure.
+Infrastructure used by our test-runner on GCP are:
+1. Cloud Tasks Queue.
+2. Workflow.
+3. Compute Engine.
+4. Firestore.
+
+Installation: 
 1. Install terraform from [Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli)
 2. Verify terraform is working locally.
 3. Create a new gcp project.

--- a/src/main/java/graphql/testrunner/resource/TestRunnerResource.java
+++ b/src/main/java/graphql/testrunner/resource/TestRunnerResource.java
@@ -24,6 +24,7 @@ public class TestRunnerResource {
         String commitHash = job.getCommitHash();
         if (nonNull(commitHash) && !isEmpty(commitHash))
             testRunnerService.runTest(job);
+        //TODO fail the job and save to the database
     }
 
     @GetMapping("/")

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -6,16 +6,16 @@ terraform {
   }
 }
 
+locals {
+  cred = file("cred.json")
+  email = lookup(jsondecode(local.cred), "client_email")
+}
+
 provider "google" {
   credentials = local.cred
   project = var.project_id
   region  = var.region
   zone    = "us-central1-c"
-}
-
-locals {
-  cred = file("cred.json")
-  email = lookup(jsondecode(local.cred), "client_email")
 }
 
 # Define and deploy a workflow
@@ -48,13 +48,17 @@ resource "google_cloud_tasks_queue" "test_runner_tasks_queue" {
     max_doublings = 1
   }
 
+  depends_on = [ google_project_service.cloud_tasks_api]
 }
 
-# Firestore
-# resource "google_app_engine_application" "firestore" {
-#   project = var.project_id
-#   location_id = "us-central"
-#   database_type = "CLOUD_FIRESTORE"
+# Enable Firestore, this operation will be successful when initializing
+# the project for the first time. Firestore once enabled can never be disabled on the same project.
+# If terraform appy is called multiple times for the same project it's ok to get the below error for firestore.
+# Error 409: This application already exists and cannot be re-created.
+resource "google_app_engine_application" "firestore" {
+  project = var.project_id
+  location_id = "us-central"
+  database_type = "CLOUD_FIRESTORE"
 
-#   depends_on = [google_project_service.app_engine_api]
-# }
+  depends_on = [google_project_service.app_engine_api]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -30,21 +30,17 @@ resource "google_workflows_workflow" "test_runner_workflow" {
 }
 
 # Define and deploy a tasks queue
+# Queue should not be named the same as any other queue created 7 days before within the same GCP account. It will throw an error.
 resource "google_cloud_tasks_queue" "test_runner_tasks_queue" {
-  name     = "test-runner-tasks-queue"
+  name     = "test-runner-tasks-queue-v1"
   location = var.region
 
   rate_limits {
-    max_concurrent_dispatches = 1000
-    max_dispatches_per_second = 500
+    max_concurrent_dispatches = 1
   }
 
   retry_config {
-    max_attempts       = 100
-    max_retry_duration = "4s"
-    max_backoff        = "3600s"
-    min_backoff        = "0.1s"
-    max_doublings      = 1
+    max_attempts = 1
   }
 
   depends_on = [google_project_service.cloud_tasks_api]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -30,7 +30,25 @@ resource "google_workflows_workflow" "test_runner_workflow" {
   depends_on = [google_project_service.workflows]
 }
 
+# Define and deploy a tasks queue
+resource "google_cloud_tasks_queue" "test_runner_tasks_queue" {
+  name = "test-runner-tasks-queue"
+  location = var.region
 
+  rate_limits {
+    max_concurrent_dispatches = 1000
+    max_dispatches_per_second = 500
+  }
+
+  retry_config {
+    max_attempts = 100
+    max_retry_duration = "4s"
+    max_backoff = "3600s"
+    min_backoff = "0.1s"
+    max_doublings = 1
+  }
+
+}
 
 # Firestore
 # resource "google_app_engine_application" "firestore" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,42 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {
+  credentials = local.cred
+  project = var.project_id
+  region  = var.region
+  zone    = "us-central1-c"
+}
+
+locals {
+  cred = file("cred.json")
+  email = lookup(jsondecode(local.cred), "client_email")
+}
+
+# Define and deploy a workflow
+resource "google_workflows_workflow" "test_runner_workflow" {
+  name = "test-runner-workflow"
+  region = var.region
+  description = "Test runner workflow"
+  service_account = local.email
+  # Import workflow YAML file
+  source_contents = file("workflow.yaml")
+
+  depends_on = [google_project_service.workflows]
+}
+
+
+
+# Firestore
+# resource "google_app_engine_application" "firestore" {
+#   project = var.project_id
+#   location_id = "us-central"
+#   database_type = "CLOUD_FIRESTORE"
+
+#   depends_on = [google_project_service.app_engine_api]
+# }

--- a/terraform/projects.tf
+++ b/terraform/projects.tf
@@ -1,0 +1,17 @@
+# Enable Workflows API
+resource "google_project_service" "workflows" {
+  service = "workflows.googleapis.com"
+  disable_dependent_services = true
+}
+
+# Enable AppEngine API - required to create datastore
+resource "google_project_service" "app_engine_api" {
+  service = "appengine.googleapis.com"
+  disable_dependent_services = true
+}
+
+# Enable ComputeEngine API - required to create compute engine instance
+resource "google_project_service" "compute_engine_api" {
+  service = "compute.googleapis.com"
+  disable_dependent_services = true
+}

--- a/terraform/projects.tf
+++ b/terraform/projects.tf
@@ -1,23 +1,32 @@
+# Enable cloud resource manager API, required to enable dependent API's.
+resource "google_project_service" "cloud_manager_api" {
+  service   = "cloudresourcemanager.googleapis.com"
+}
+
 # Enable Workflows API
 resource "google_project_service" "workflows" {
   service = "workflows.googleapis.com"
   disable_dependent_services = true
+  depends_on = [google_project_service.cloud_manager_api]
 }
 
 # Enable AppEngine API - required to create datastore
 resource "google_project_service" "app_engine_api" {
   service = "appengine.googleapis.com"
   disable_dependent_services = true
+  depends_on = [google_project_service.cloud_manager_api]
 }
 
 # Enable ComputeEngine API - required to create compute engine instance
 resource "google_project_service" "compute_engine_api" {
   service = "compute.googleapis.com"
   disable_dependent_services = true
+  depends_on = [google_project_service.cloud_manager_api]
 }
 
 # Enable Cloud Tasks Queue API - required to create a queue
 resource "google_project_service" "cloud_tasks_api" {
   service = "cloudtasks.googleapis.com"
   disable_dependent_services = true
+  depends_on = [google_project_service.cloud_manager_api]
 }

--- a/terraform/projects.tf
+++ b/terraform/projects.tf
@@ -1,32 +1,32 @@
 # Enable cloud resource manager API, required to enable dependent API's.
 resource "google_project_service" "cloud_manager_api" {
-  service   = "cloudresourcemanager.googleapis.com"
+  service = "cloudresourcemanager.googleapis.com"
 }
 
 # Enable Workflows API
 resource "google_project_service" "workflows" {
-  service = "workflows.googleapis.com"
+  service                    = "workflows.googleapis.com"
   disable_dependent_services = true
-  depends_on = [google_project_service.cloud_manager_api]
+  depends_on                 = [google_project_service.cloud_manager_api]
 }
 
 # Enable AppEngine API - required to create datastore
 resource "google_project_service" "app_engine_api" {
-  service = "appengine.googleapis.com"
+  service                    = "appengine.googleapis.com"
   disable_dependent_services = true
-  depends_on = [google_project_service.cloud_manager_api]
+  depends_on                 = [google_project_service.cloud_manager_api]
 }
 
 # Enable ComputeEngine API - required to create compute engine instance
 resource "google_project_service" "compute_engine_api" {
-  service = "compute.googleapis.com"
+  service                    = "compute.googleapis.com"
   disable_dependent_services = true
-  depends_on = [google_project_service.cloud_manager_api]
+  depends_on                 = [google_project_service.cloud_manager_api]
 }
 
 # Enable Cloud Tasks Queue API - required to create a queue
 resource "google_project_service" "cloud_tasks_api" {
-  service = "cloudtasks.googleapis.com"
+  service                    = "cloudtasks.googleapis.com"
   disable_dependent_services = true
-  depends_on = [google_project_service.cloud_manager_api]
+  depends_on                 = [google_project_service.cloud_manager_api]
 }

--- a/terraform/projects.tf
+++ b/terraform/projects.tf
@@ -15,3 +15,9 @@ resource "google_project_service" "compute_engine_api" {
   service = "compute.googleapis.com"
   disable_dependent_services = true
 }
+
+# Enable Cloud Tasks Queue API - required to create a queue
+resource "google_project_service" "cloud_tasks_api" {
+  service = "cloudtasks.googleapis.com"
+  disable_dependent_services = true
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,9 @@
+variable "project_id" {
+  type        = string
+  description = "Google Cloud Platform Project ID"
+}
+
+variable "region" {
+  default = "us-central1"
+  type    = string
+}

--- a/terraform/workflow.yaml
+++ b/terraform/workflow.yaml
@@ -1,0 +1,157 @@
+main:
+  params: [job]
+  steps:
+    - vars:
+        assign:
+          - project_id: ${sys.get_env("GOOGLE_CLOUD_PROJECT_ID")}
+          - collection: "test-runs"
+          - job_id: ${job.jobId}
+          - zone: "us-west1-b"
+          - region: "us-west1"
+          - instance_name: "test-runner"
+          - machine_type: "e2-small"
+          - project_number: ${sys.get_env("GOOGLE_CLOUD_PROJECT_NUMBER")}
+          - service_account_email: ${project_number + "-compute@developer.gserviceaccount.com"}
+
+    - create_job_in_firestore:
+        call: googleapis.firestore.v1.projects.databases.documents.createDocument
+        args:
+          collectionId: ${collection}
+          parent: ${"projects/" + project_id + "/databases/(default)/documents"}
+          query:
+            documentId: ${job_id}
+          body:
+            fields:
+              jobId:
+                stringValue: ${job_id}
+    - get_document:
+        call: googleapis.firestore.v1.projects.databases.documents.get
+        args:
+          name: ${"projects/" + project_id + "/databases/(default)/documents/" + collection + "/" + job_id}
+        result: got
+    - validate_saved_document:
+        switch:
+          - condition: ${got.fields.jobId.stringValue == job_id}
+            next: get_latest_image
+    - failed:
+        raise: ${"got unexpected document"}
+
+
+    #Get latest boot image.
+    - get_latest_image:
+        call: googleapis.compute.v1.images.getFromFamily
+        args:
+          family: "cos-stable"
+          project: "cos-cloud"
+        result: getFromFamilyResult
+
+    #Create and start compute engine vm.
+    - insert_machine:
+        call: googleapis.compute.v1.instances.insert
+        args:
+          project: ${project_id}
+          zone: ${zone}
+          body:
+            tags:
+              items:
+                - http-server
+            name: ${instance_name}
+            machineType: ${"zones/" + zone + "/machineTypes/" + machine_type}
+            disks:
+              - initializeParams:
+                  sourceImage: ${"projects/cos-cloud/global/images/" + getFromFamilyResult.name}
+                boot: true
+                autoDelete: true
+            networkInterfaces:
+              - accessConfigs:
+                  - name: "External NAT"
+                    networkTier: "STANDARD"
+                subnetwork: ${"projects/" + project_id + "/regions/" + region +"/subnetworks/default"}
+            metadata:
+              items:
+                - key: "startup-script"
+                  value: "#! /bin/bash \ncd tmp\nmkdir test-runner\ncd test-runner\npwd\nls\ngit clone https://github.com/adarsh-jaiswal/graphql-java-test-runner.git\ncd graphql-java-test-runner/ \ngit checkout bcf3a7a \ndocker build --no-cache -t test-runner .\ndocker run --publish 80:8080 test-runner"
+
+            serviceAccounts:
+              - email: ${service_account_email}
+                scopes:
+                  - https://www.googleapis.com/auth/cloud-platform
+    - assert_machine_is_running:
+        call: assert_machine_status
+        args:
+          expected_status: "RUNNING"
+          zone: ${zone}
+          project: ${project_id}
+          instance: ${instance_name}
+
+    - get_instance:
+        call: googleapis.compute.v1.instances.get
+        args:
+          instance: ${instance_name}
+          project: ${project_id}
+          zone: ${zone}
+        result: created_instance
+
+    #Extract compute engine's url.
+    - extract_external_ip_and_construct_urls:
+        assign:
+          - external_ip: ${created_instance.networkInterfaces[0].accessConfigs[0].natIP}
+          - base_url: ${"http://" + external_ip + "/"}
+
+    #Perform call to test-runner.
+    - check_test_runner_is_running:
+        try:
+          call: http.get
+          args:
+            url: ${base_url}
+        retry: ${http.default_retry}
+
+    - call_test_runner:
+        call: http.post
+        args:
+          url: ${base_url + "test-runner"}
+          body: ${job}
+        result: output_result
+
+
+    #Destroy compute engine.
+    - stop_machine:
+        call: googleapis.compute.v1.instances.stop
+        args:
+          instance: ${instance_name}
+          project: ${project_id}
+          zone: ${zone}
+    - assert_terminated:
+        call: assert_machine_status
+        args:
+          expected_status: "TERMINATED"
+          zone: ${zone}
+          project: ${project_id}
+          instance: ${instance_name}
+    - delete_machine:
+        call: googleapis.compute.v1.instances.delete
+        args:
+          instance: ${instance_name}
+          project: ${project_id}
+          zone: ${zone}
+
+    - returnOutput:
+        return: "SUCCESS"
+
+
+assert_machine_status:
+  params: [expected_status, project, zone, instance]
+  steps:
+    - get_instance:
+        call: googleapis.compute.v1.instances.get
+        args:
+          instance: ${instance}
+          project: ${project}
+          zone: ${zone}
+        result: instance
+    - compare:
+        switch:
+          - condition: ${instance.status == expected_status}
+            next: end
+    - fail:
+        raise: ${"Expected VM status is " + expected_status + ". Got " + instance.status + " instead."}

--- a/terraform/workflow.yaml
+++ b/terraform/workflow.yaml
@@ -36,15 +36,13 @@ main:
     - failed:
         raise: ${"got unexpected document"}
 
-
-    #Get latest boot image.
+    #Get the latest boot image.
     - get_latest_image:
         call: googleapis.compute.v1.images.getFromFamily
         args:
           family: "cos-stable"
           project: "cos-cloud"
         result: getFromFamilyResult
-
     #Create and start compute engine vm.
     - insert_machine:
         call: googleapis.compute.v1.instances.insert
@@ -71,7 +69,6 @@ main:
               items:
                 - key: "startup-script"
                   value: "#! /bin/bash \ncd tmp\nmkdir test-runner\ncd test-runner\npwd\nls\ngit clone https://github.com/adarsh-jaiswal/graphql-java-test-runner.git\ncd graphql-java-test-runner/ \ngit checkout bcf3a7a \ndocker build --no-cache -t test-runner .\ndocker run --publish 80:8080 test-runner"
-
             serviceAccounts:
               - email: ${service_account_email}
                 scopes:
@@ -84,6 +81,7 @@ main:
           project: ${project_id}
           instance: ${instance_name}
 
+    #Extract compute engine's url.
     - get_instance:
         call: googleapis.compute.v1.instances.get
         args:
@@ -91,8 +89,6 @@ main:
           project: ${project_id}
           zone: ${zone}
         result: created_instance
-
-    #Extract compute engine's url.
     - extract_external_ip_and_construct_urls:
         assign:
           - external_ip: ${created_instance.networkInterfaces[0].accessConfigs[0].natIP}
@@ -105,14 +101,12 @@ main:
           args:
             url: ${base_url}
         retry: ${http.default_retry}
-
-    - call_test_runner:
+    - execute_test_run:
         call: http.post
         args:
           url: ${base_url + "test-runner"}
           body: ${job}
         result: output_result
-
 
     #Destroy compute engine.
     - stop_machine:

--- a/terraform/workflow.yaml
+++ b/terraform/workflow.yaml
@@ -36,14 +36,14 @@ main:
     - failed:
         raise: ${"got unexpected document"}
 
-    #Get the latest boot image.
+    # Get the latest boot image.
     - get_latest_image:
         call: googleapis.compute.v1.images.getFromFamily
         args:
           family: "cos-stable"
           project: "cos-cloud"
         result: getFromFamilyResult
-    #Create and start compute engine vm.
+    # Create and start compute engine vm.
     - insert_machine:
         call: googleapis.compute.v1.instances.insert
         args:
@@ -81,7 +81,7 @@ main:
           project: ${project_id}
           instance: ${instance_name}
 
-    #Extract compute engine's url.
+    # Extract compute engine's url.
     - get_instance:
         call: googleapis.compute.v1.instances.get
         args:
@@ -94,7 +94,7 @@ main:
           - external_ip: ${created_instance.networkInterfaces[0].accessConfigs[0].natIP}
           - base_url: ${"http://" + external_ip + "/"}
 
-    #Perform call to test-runner.
+    # Perform call to test-runner.
     - check_test_runner_is_running:
         try:
           call: http.get
@@ -108,7 +108,7 @@ main:
           body: ${job}
         result: output_result
 
-    #Destroy compute engine.
+    # Destroy compute engine.
     - stop_machine:
         call: googleapis.compute.v1.instances.stop
         args:


### PR DESCRIPTION
Initial terraform setup.
Manual steps for orchestration-
1. Create a new gcp project.
2. Create service account on IAM & Admin->Service Account-> Create Service Account.
Give the role as Basic->owner.
3. Select the service account created above, then go to Actions->Manage keys->Add key->create new key->JSON.
4. Download the key from above step and paste it in the terraform directory. Rename it as **cred.json**.
5. Open terminal in **terraform** directory.
6. Run **terraform init** 
7. Run **terraform apply -var project_id=**_your project id present in cred.json_

Terraform will take care of all the infrastructure required by the test runner.

FYI: Firestore can be enabled only once per project and it can never be destroyed.
 