### PR TITLE
removed docker layer

### DIFF
--- a/test-runner-backend/terraform/main.tf
+++ b/test-runner-backend/terraform/main.tf
@@ -20,7 +20,7 @@ provider "google" {
 
 # Define and deploy a workflow
 resource "google_workflows_workflow" "test_runner_workflow" {
-  name            = "test-runner-workflow"
+  name            = "test-runner-workflow-v2"
   region          = var.region
   description     = "Test runner workflow"
   service_account = local.email
@@ -32,7 +32,7 @@ resource "google_workflows_workflow" "test_runner_workflow" {
 # Define and deploy a tasks queue
 # Queue should not be named the same as any other queue created 7 days before within the same GCP account. It will throw an error.
 resource "google_cloud_tasks_queue" "test_runner_tasks_queue" {
-  name     = "test-runner-tasks-queue-v1"
+  name     = "test-runner-tasks-queue-v2"
   location = var.region
 
   rate_limits {
@@ -61,7 +61,7 @@ resource "google_app_engine_application" "firestore" {
 # Create a firewall rule to allow http communication to compute instance.
 resource "google_compute_firewall" "rules" {
   project     = var.project_id
-  name        = "allow-http-firewall-rule"
+  name        = "allow-http-firewall-rule-v2"
   network     = "default"
   description = "Creates firewall rule targeting tagged instances"
 

--- a/test-runner-backend/terraform/workflow.yaml
+++ b/test-runner-backend/terraform/workflow.yaml
@@ -39,17 +39,9 @@ main:
     - validate_saved_document:
         switch:
           - condition: ${got.fields.jobId.stringValue == job_id AND got.fields.status.mapValue.fields.core_2.stringValue == "CREATED"}
-            next: get_latest_image
+            next: parallel_step
     - failed:
         raise: ${"got unexpected document"}
-
-    # Get the latest boot image.
-    - get_latest_image:
-        call: googleapis.compute.v1.images.getFromFamily
-        args:
-          family: "cos-stable"
-          project: "cos-cloud"
-        result: getFromFamilyResult
 
     # Create, start, execute tests and delete compute engine vm in parallel.
     - parallel_step:
@@ -74,7 +66,7 @@ main:
                       machineType: ${"zones/" + zone + "/machineTypes/" + machine}
                       disks:
                         - initializeParams:
-                            sourceImage: ${"projects/cos-cloud/global/images/" + getFromFamilyResult.name}
+                            sourceImage: "projects/debian-cloud/global/images/family/debian-10"
                           boot: true
                           autoDelete: true
                       networkInterfaces:
@@ -85,7 +77,34 @@ main:
                       metadata:
                         items:
                           - key: "startup-script"
-                            value: "#! /bin/bash \ncd tmp\nmkdir test-runner\ncd test-runner\ngit clone https://github.com/adarsh-jaiswal/graphql-java-test-runner.git\ncd graphql-java-test-runner/ \ncd test-runner-backend \ndocker build --no-cache -t test-runner .\ndocker run --publish 80:8080 test-runner"
+                            value: |
+                              #! /bin/bash
+                              # We will an Azul Zulu build of jdk-8, since we can no longer install
+                              # it directly.
+
+                              # Add Azul's public key
+                              sudo apt-key adv \
+                                --keyserver hkp://keyserver.ubuntu.com:80 \
+                                --recv-keys 0xB1998361219BD9C9
+
+                              # Download and install the package that adds 
+                              # the Azul APT repository to the list of sources 
+                              curl -O https://cdn.azul.com/zulu/bin/zulu-repo_1.0.0-3_all.deb
+                              sudo apt-get install ./zulu-repo_1.0.0-3_all.deb
+                              sudo apt-get update
+
+                              # Install git and open zulu open jdk
+                              sudo apt-get install zulu8-jdk -y
+                              sudo apt-get install git -y
+
+                              # Install Test Runner
+                              git clone https://github.com/adarsh-jaiswal/graphql-java-test-runner.git
+                              cd graphql-java-test-runner
+                              cd test-runner-backend
+                              ./gradlew build
+                              cd build/libs
+                              sudo nohup java -jar -Dserver.port=80 graphql-java-test-runner-0.0.1-SNAPSHOT.jar &
+
                       serviceAccounts:
                         - email: ${service_account_email}
                           scopes:


### PR DESCRIPTION
## What
this change removes the docker layer and runs the jvm directly on the vm.

## Why
when running benchmark tests, we want to make sure docker isn't interfering with the performance of the jvm. we can remove the layer entirely so that we have fewer parameters to tweak in the future. 

## Testing
* Tested all benchmarks with the following payload:
```
{
  "classes": [
    "AddError"
  ],
  "commitHash": "21955383d484c2a37f49bbadefcac77f4085f45d",
  "jobId": "645c4646-7243-4850-ba3f-ae209306b99b"
}
```

* Tested a single benchmark with the following payload:
```
{
  "classes": ["addError"],
  "commitHash": "21955383d484c2a37f49bbadefcac77f4085f45d",
  "jobId": "2368b170-b20f-4b5c-827a-295d29bd5853"
}
```